### PR TITLE
Update README.md to use Rust syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pub fn timeout_complete() -> () {
 
 Want to use [async-std](https://async.rs/)?
 
-```
+```rust
 async fn run() {
     println!("hello");
     async_std::task::sleep(std::time::Duration::from_secs(1)).await;


### PR DESCRIPTION
This micro PR updates the second code block in the README to use Rust syntax highlighting.