### PR TITLE
Make task list pop more efficient

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl Executor {
     // Poll all tasks on global executor
     fn poll_tasks(&mut self) {
         for _ in 0..self.tasks.len() {
-            let task = self.tasks.remove(0).unwrap();
+            let task = self.tasks.pop_front().unwrap();
             if task.is_pending() {
                 self.tasks.push_back(task);
             }


### PR DESCRIPTION
The task list is stored in a `VecDeque`.

`VecDeque::pop_front()` is more efficient than `VecDeque::remove(0)`
because the latter needs to support removing elements in the middle.

Using `pop_front()` improves performance considerably on tiny
embedded CPUs such as PICs.